### PR TITLE
feat: add Flutter client skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,12 @@ __marimo__/
 */_pycache/
 */__pycache__/
 */.vscode/
+
+# Allow Flutter client sources
+!gitdm_client/lib/
+!gitdm_client/lib/**
+!gitdm_client/test/
+!gitdm_client/test/**
+!gitdm_client/pubspec.yaml
+!gitdm_client/README.md
+!gitdm_client/.gitignore

--- a/gitdm_client/.gitignore
+++ b/gitdm_client/.gitignore
@@ -1,0 +1,12 @@
+# پوشه‌های تولیدی فلان
+.dart_tool/
+.packages
+build/
+ios/
+android/
+macos/
+linux/
+windows/
+web/
+# فایل قفل pub؛ در صورت نیاز می‌توان آن را افزود
+pubspec.lock

--- a/gitdm_client/README.md
+++ b/gitdm_client/README.md
@@ -1,0 +1,19 @@
+# GitDM Flutter Client
+
+این پوشه یک اسکلت ساده برای کلاینت Flutter جهت ارتباط با بک‌اند Django/DRF پروژه‌ی GitDM است.
+
+## اجرای اولیه
+```bash
+flutter pub get
+flutter run --dart-define=API_BASE_URL=http://127.0.0.1:8000
+```
+
+> برای اندروید، اطمینان حاصل کنید که مجوز اینترنت در `android/app/src/main/AndroidManifest.xml` اضافه شده باشد:
+> ```xml
+> <uses-permission android:name="android.permission.INTERNET" />
+> ```
+
+## وابستگی‌ها
+- `dio` برای درخواست‌های HTTP و اینترسپتور
+- `provider` برای مدیریت ساده‌ی state
+- `shared_preferences` برای ذخیره‌ی ساده‌ی توکن‌ها (برای محصول نهایی بهتر است از secure storage استفاده شود)

--- a/gitdm_client/lib/app.dart
+++ b/gitdm_client/lib/app.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'features/auth/ui/login_page.dart';
+import 'features/patients/ui/patient_list_page.dart';
+
+/// \u0645\u0633\u06cc\u0631\u0628\u0646\u062f\u06cc \u0633\u0627\u062f\u0647\u0654 \u0627\u067e:
+/// - '/' \u2192 \u0635\u0641\u062d\u0647\u0654 \u0648\u0631\u0648\u062f
+/// - '/patients' \u2192 \u0644\u06cc\u0633\u062a \u0628\u06cc\u0645\u0627\u0631\u0627\u0646
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'GitDM Client',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: const Color(0xFF0B7)),
+      initialRoute: '/',
+      routes: {
+        '/': (_) => const LoginPage(),
+        '/patients': (_) => const PatientListPage(),
+      },
+    );
+  }
+}

--- a/gitdm_client/lib/core/api_client.dart
+++ b/gitdm_client/lib/core/api_client.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import 'config.dart';
+import 'token_storage.dart';
+
+/// \u06a9\u0644\u0627\u06cc\u0646\u062a \u0627\u0635\u0644\u06cc Dio \u0628\u0627 \u0627\u06cc\u0646\u062a\u0631\u0633\u067e\u062a\u0648\u0631 \u0628\u0631\u0627\u06cc:
+/// 1) \u0627\u0641\u0632\u0648\u062f\u0646 \u0647\u062f\u0631 Authorization \u0628\u0627 access token
+/// 2) \u0647\u0646\u062f\u0644 401 \u2192 \u0631\u0641\u0631\u0634 \u062a\u0648\u06a9\u0646 \u0628\u0627 /api/token/refresh/ \u0648 \u062a\u06a9\u0631\u0627\u0631 \u0647\u0645\u0627\u0646 \u062f\u0631\u062e\u0648\u0627\u0633\u062a
+class ApiClient {
+  final Dio _dio;
+  final TokenStorage _storage;
+
+  ApiClient(this._storage)
+      : _dio = Dio(BaseOptions(
+          baseUrl: AppConfig.apiBaseUrl + AppConfig.apiPrefix, // \u0645\u062b\u0644: http://localhost:8000/api
+          connectTimeout: const Duration(seconds: 15),
+          receiveTimeout: const Duration(seconds: 20),
+          headers: {'Accept': 'application/json'},
+        )) {
+    _dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        final access = await _storage.getAccess();
+        if (access != null && access.isNotEmpty) {
+          options.headers['Authorization'] = 'Bearer ' + access;
+        }
+        return handler.next(options);
+      },
+      onError: (e, handler) async {
+        if (e.response?.statusCode == 401) {
+          final refreshed = await _tryRefreshToken();
+          if (refreshed) {
+            final req = e.requestOptions;
+            final access = await _storage.getAccess();
+            req.headers['Authorization'] = 'Bearer ' + access!;
+            try {
+              final clone = await _dio.fetch(req);
+              return handler.resolve(clone);
+            } catch (e2) {
+              return handler.reject(e2 as DioException);
+            }
+          }
+        }
+        return handler.next(e);
+      },
+    ));
+  }
+
+  Dio get dio => _dio;
+
+  /// \u0641\u0631\u0627\u062e\u0648\u0627\u0646\u06cc /api/token/refresh/ \u0637\u0628\u0642 SimpleJWT
+  Future<bool> _tryRefreshToken() async {
+    final refresh = await _storage.getRefresh();
+    if (refresh == null || refresh.isEmpty) return false;
+
+    try {
+      final resp = await _dio.post('/token/refresh/', data: {'refresh': refresh});
+      final data = resp.data as Map<String, dynamic>;
+      final newAccess = data['access'] as String?;
+      final newRefresh = (data['refresh'] as String?) ?? refresh;
+
+      if (newAccess != null && newAccess.isNotEmpty) {
+        await _storage.saveTokens(access: newAccess, refresh: newRefresh);
+        return true;
+      }
+      return false;
+    } on DioException {
+      await _storage.clear();
+      return false;
+    }
+  }
+}

--- a/gitdm_client/lib/core/config.dart
+++ b/gitdm_client/lib/core/config.dart
@@ -1,0 +1,13 @@
+/// \u062a\u0646\u0638\u06cc\u0645\u0627\u062a \u067e\u0627\u06cc\u0647\u0654 \u0627\u067e.
+/// \u0622\u062f\u0631\u0633 \u0628\u06a9\u200c\u0627\u0646\u062f \u0628\u0627 --dart-define \u067e\u0627\u0633 \u0645\u06cc\u200c\u0634\u0648\u062f \u062a\u0627 \u062f\u0631 \u06a9\u062f \u0647\u0627\u0631\u062f\u06a9\u064f\u062f \u0646\u0628\u0627\u0634\u062f.
+/// \u0645\u062b\u0627\u0644 \u0627\u062c\u0631\u0627:
+/// flutter run --dart-define=API_BASE_URL=http://localhost:8000
+class AppConfig {
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:8000',
+  );
+
+  /// \u067e\u06cc\u0634\u0648\u0646\u062f \u0647\u0645\u0647\u0654 \u0627\u0646\u062f\u067e\u0648\u06cc\u0646\u062a\u200c\u0647\u0627\u06cc DRF \u0637\u0628\u0642 README
+  static const String apiPrefix = '/api';
+}

--- a/gitdm_client/lib/core/token_storage.dart
+++ b/gitdm_client/lib/core/token_storage.dart
@@ -1,0 +1,31 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// \u0646\u06af\u0647\u062f\u0627\u0631\u06cc \u062a\u0648\u06a9\u0646\u200c\u0647\u0627\u06cc JWT \u062f\u0631 \u06a9\u0644\u0627\u06cc\u0646\u062a.
+/// \u0646\u06a9\u062a\u0647 \u0627\u0645\u0646\u06cc\u062a\u06cc: \u0628\u0631\u0627\u06cc \u0645\u062d\u0635\u0648\u0644 \u0646\u0647\u0627\u06cc\u06cc \u0628\u0647\u062a\u0631 \u0627\u0633\u062a \u0627\u0632 flutter_secure_storage \u0627\u0633\u062a\u0641\u0627\u062f\u0647 \u0634\u0648\u062f.
+/// \u0627\u06cc\u0646\u062c\u0627 \u0628\u0631\u0627\u06cc \u0633\u0627\u062f\u06af\u06cc PoC \u0627\u0632 SharedPreferences \u0627\u0633\u062a\u0641\u0627\u062f\u0647 \u0645\u06cc\u200c\u06a9\u0646\u06cc\u0645.
+class TokenStorage {
+  static const _kAccess = 'access_token';
+  static const _kRefresh = 'refresh_token';
+
+  Future<void> saveTokens({required String access, required String refresh}) async {
+    final sp = await SharedPreferences.getInstance();
+    await sp.setString(_kAccess, access);
+    await sp.setString(_kRefresh, refresh);
+  }
+
+  Future<String?> getAccess() async {
+    final sp = await SharedPreferences.getInstance();
+    return sp.getString(_kAccess);
+  }
+
+  Future<String?> getRefresh() async {
+    final sp = await SharedPreferences.getInstance();
+    return sp.getString(_kRefresh);
+  }
+
+  Future<void> clear() async {
+    final sp = await SharedPreferences.getInstance();
+    await sp.remove(_kAccess);
+    await sp.remove(_kRefresh);
+  }
+}

--- a/gitdm_client/lib/features/auth/models/token_pair.dart
+++ b/gitdm_client/lib/features/auth/models/token_pair.dart
@@ -1,0 +1,15 @@
+/// \u0645\u062f\u0644 \u0633\u0627\u062f\u0647\u0654 \u062a\u0648\u06a9\u0646\u200c\u0647\u0627.
+/// \u067e\u0627\u0633\u062e /api/token/ \u0645\u0639\u0645\u0648\u0644\u0627\u064b \u0634\u0627\u0645\u0644 access \u0648 refresh \u0627\u0633\u062a.
+class TokenPair {
+  final String access;
+  final String refresh;
+
+  TokenPair({required this.access, required this.refresh});
+
+  factory TokenPair.fromJson(Map<String, dynamic> json) {
+    return TokenPair(
+      access: (json['access'] ?? '') as String,
+      refresh: (json['refresh'] ?? '') as String,
+    );
+  }
+}

--- a/gitdm_client/lib/features/auth/repo/auth_repository.dart
+++ b/gitdm_client/lib/features/auth/repo/auth_repository.dart
@@ -1,0 +1,32 @@
+import 'package:dio/dio.dart';
+import '../../../core/api_client.dart';
+import '../../../core/token_storage.dart';
+import '../models/token_pair.dart';
+
+/// \u0631\u06cc\u067e\u0627\u0632\u06cc\u062a\u0648\u0631\u06cc \u0627\u062d\u0631\u0627\u0632 \u0647\u0648\u06cc\u062a:
+/// - login: \u062f\u0631\u06cc\u0627\u0641\u062a access/refresh \u0627\u0632 /api/token/
+/// - logout: \u067e\u0627\u06a9\u200c\u06a9\u0631\u062f\u0646 \u062a\u0648\u06a9\u0646\u200c\u0647\u0627
+class AuthRepository {
+  final ApiClient _client;
+  final TokenStorage _storage;
+
+  AuthRepository(this._client, this._storage);
+
+  Future<void> login({required String username, required String password}) async {
+    // \u062f\u0631 DRF SimpleJWT\u060c \u0641\u06cc\u0644\u062f\u0647\u0627 \u0645\u0645\u06a9\u0646 \u0627\u0633\u062a username/password \u06cc\u0627 email/password \u0628\u0627\u0634\u062f.
+    final Response resp = await _client.dio.post('/token/', data: {
+      'username': username,
+      'password': password,
+    });
+
+    final pair = TokenPair.fromJson(resp.data as Map<String, dynamic>);
+    if (pair.access.isEmpty || pair.refresh.isEmpty) {
+      throw Exception('Invalid token response');
+    }
+    await _storage.saveTokens(access: pair.access, refresh: pair.refresh);
+  }
+
+  Future<void> logout() async {
+    await _storage.clear();
+  }
+}

--- a/gitdm_client/lib/features/auth/ui/login_page.dart
+++ b/gitdm_client/lib/features/auth/ui/login_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../auth/repo/auth_repository.dart';
+
+/// \u0635\u0641\u062d\u0647\u0654 \u0648\u0631\u0648\u062f \u0633\u0627\u062f\u0647:
+/// - \u062f\u0648 \u0641\u06cc\u0644\u062f username/password
+/// - \u0631\u0648\u06cc \u0645\u0648\u0641\u0642\u06cc\u062a\u060c \u0646\u0627\u0648\u0628\u0631\u06cc \u0628\u0647 \u0644\u06cc\u0633\u062a \u0628\u06cc\u0645\u0627\u0631\u0627\u0646
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _userCtrl = TextEditingController();
+  final _passCtrl = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  Future<void> _onLogin() async {
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final authRepo = context.read<AuthRepository>();
+
+      await authRepo.login(
+        username: _userCtrl.text.trim(),
+        password: _passCtrl.text,
+      );
+
+      if (!mounted) return;
+      Navigator.of(context).pushReplacementNamed('/patients');
+    } catch (e) {
+      setState(() => _error = '\u0648\u0631\u0648\u062f \u0646\u0627\u0645\u0648\u0641\u0642. \u0644\u0637\u0641\u0627\u064b \u0627\u0637\u0644\u0627\u0639\u0627\u062a \u0631\u0627 \u0628\u0631\u0631\u0633\u06cc \u06a9\u0646\u06cc\u062f.');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('\u0648\u0631\u0648\u062f')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(controller: _userCtrl, decoration: const InputDecoration(labelText: '\u0646\u0627\u0645 \u06a9\u0627\u0631\u0628\u0631\u06cc/\u0627\u06cc\u0645\u06cc\u0644')),
+            const SizedBox(height: 8),
+            TextField(controller: _passCtrl, decoration: const InputDecoration(labelText: '\u0631\u0645\u0632 \u0639\u0628\u0648\u0631'), obscureText: true),
+            const SizedBox(height: 16),
+            if (_error != null) Text(_error!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _busy ? null : _onLogin,
+                child: _busy ? const CircularProgressIndicator() : const Text('\u0648\u0631\u0648\u062f'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/gitdm_client/lib/features/patients/models/patient.dart
+++ b/gitdm_client/lib/features/patients/models/patient.dart
@@ -1,0 +1,22 @@
+/// \u0645\u062f\u0644 \u0645\u06cc\u0646\u06cc\u0645\u0627\u0644 \u0628\u06cc\u0645\u0627\u0631.
+/// \u0641\u06cc\u0644\u062f\u0647\u0627 \u0645\u0645\u06a9\u0646 \u0627\u0633\u062a \u062f\u0631 \u0628\u06a9\u200c\u0627\u0646\u062f \u0634\u0645\u0627 \u0645\u062e\u062a\u0644\u0641 \u0628\u0627\u0634\u0646\u062f.
+/// \u0627\u06cc\u0646\u062c\u0627 \u0686\u0646\u062f \u0641\u06cc\u0644\u062f \u0631\u0627\u06cc\u062c \u0631\u0627 \u062f\u0631 \u0646\u0638\u0631 \u0645\u06cc\u200c\u06af\u06cc\u0631\u06cc\u0645\u061b \u062f\u0631 \u0635\u0648\u0631\u062a \u0646\u06cc\u0627\u0632 \u0628\u0627 API \u0648\u0627\u0642\u0639\u06cc \u0647\u0645\u0627\u0647\u0646\u06af \u06a9\u0646\u06cc\u062f.
+class Patient {
+  final int id;
+  final String fullName;
+
+  Patient({required this.id, required this.fullName});
+
+  factory Patient.fromJson(Map<String, dynamic> json) {
+    final first = (json['first_name'] ?? json['firstName'] ?? json['name'] ?? '').toString();
+    final last  = (json['last_name'] ?? json['lastName'] ?? '').toString();
+    final combined = (first.isNotEmpty && last.isNotEmpty)
+        ? '$first $last'
+        : (first.isNotEmpty ? first : (last.isNotEmpty ? last : ''));
+
+    return Patient(
+      id: (json['id'] ?? 0) as int,
+      fullName: combined.isNotEmpty ? combined : '\u0646\u0627\u0645\u200c\u0646\u0627\u0645\u0634\u062e\u0635',
+    );
+  }
+}

--- a/gitdm_client/lib/features/patients/repo/patient_repository.dart
+++ b/gitdm_client/lib/features/patients/repo/patient_repository.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+import '../../../core/api_client.dart';
+import '../models/patient.dart';
+
+/// \u0631\u06cc\u067e\u0627\u0632\u06cc\u062a\u0648\u0631\u06cc \u0628\u06cc\u0645\u0627\u0631\u0627\u0646: \u06a9\u0627\u0631 \u0628\u0627 \u0627\u0646\u062f\u067e\u0648\u06cc\u0646\u062a\u200c\u0647\u0627\u06cc /api/patients/
+/// \u0637\u0628\u0642 README: CRUD \u0628\u06cc\u0645\u0627\u0631\u0627\u0646 \u0627\u06cc\u0646 \u0645\u0633\u06cc\u0631 \u0631\u0627 \u062f\u0627\u0631\u062f.
+class PatientRepository {
+  final ApiClient _client;
+  PatientRepository(this._client);
+
+  Future<List<Patient>> listPatients() async {
+    final Response resp = await _client.dio.get('/patients/');
+    final data = resp.data;
+
+    if (data is List) {
+      return data.map((e) => Patient.fromJson(e as Map<String, dynamic>)).toList();
+    }
+
+    // \u0627\u06af\u0631 DRF \u0634\u0645\u0627 pagination \u062f\u0627\u0631\u062f (results \u062f\u0627\u062e\u0644 dict)\u060c \u0647\u0646\u062f\u0644 \u0645\u06cc\u200c\u06a9\u0646\u06cc\u0645:
+    if (data is Map<String, dynamic> && data['results'] is List) {
+      final list = data['results'] as List;
+      return list.map((e) => Patient.fromJson(e as Map<String, dynamic>)).toList();
+    }
+
+    return [];
+  }
+}

--- a/gitdm_client/lib/features/patients/ui/patient_list_page.dart
+++ b/gitdm_client/lib/features/patients/ui/patient_list_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../repo/patient_repository.dart';
+import '../models/patient.dart';
+
+/// \u0635\u0641\u062d\u0647\u0654 \u0644\u06cc\u0633\u062a \u0628\u06cc\u0645\u0627\u0631\u0627\u0646 (Read-only \u0627\u0648\u0644\u06cc\u0647)
+class PatientListPage extends StatefulWidget {
+  const PatientListPage({super.key});
+
+  @override
+  State<PatientListPage> createState() => _PatientListPageState();
+}
+
+class _PatientListPageState extends State<PatientListPage> {
+  List<Patient> _items = [];
+  bool _loading = true;
+  String? _error;
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final repo = context.read<PatientRepository>();
+      final data = await repo.listPatients();
+      if (mounted) setState(() => _items = data);
+    } catch (e) {
+      if (mounted) {
+        setState(() => _error = '\u062e\u0637\u0627 \u062f\u0631 \u062f\u0631\u06cc\u0627\u0641\u062a \u0644\u06cc\u0633\u062a \u0628\u06cc\u0645\u0627\u0631\u0627\u0646');
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('\u0628\u06cc\u0645\u0627\u0631\u0627\u0646')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(child: Text(_error!))
+              : ListView.separated(
+                  itemCount: _items.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (context, i) {
+                    final p = _items[i];
+                    return ListTile(
+                      title: Text(p.fullName),
+                      subtitle: Text('\u0634\u0646\u0627\u0633\u0647: ${p.id}'),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/gitdm_client/lib/main.dart
+++ b/gitdm_client/lib/main.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'app.dart';
+import 'core/config.dart';
+import 'core/api_client.dart';
+import 'core/token_storage.dart';
+import 'features/auth/repo/auth_repository.dart';
+import 'features/patients/repo/patient_repository.dart';
+
+/// \u0646\u0642\u0637\u0647\u0654 \u0634\u0631\u0648\u0639 \u0627\u067e.
+/// - \u0633\u0627\u062e\u062a \u0648 \u062a\u0632\u0631\u06cc\u0642 TokenStorage \u0648 ApiClient \u0628\u0627 Provider
+/// - \u0686\u0627\u067e \u0622\u062f\u0631\u0633 \u0628\u06a9\u200c\u0627\u0646\u062f \u0628\u0631\u0627\u06cc \u0627\u0637\u0645\u06cc\u0646\u0627\u0646 \u0627\u0632 \u062f\u0631\u06cc\u0627\u0641\u062a dart-define
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  final storage = TokenStorage();
+  final api = ApiClient(storage);
+  final authRepo = AuthRepository(api, storage);
+  final patientRepo = PatientRepository(api);
+
+  // \u0635\u0631\u0641\u0627\u064b \u0628\u0631\u0627\u06cc \u062f\u06cc\u0628\u0627\u06af: \u0646\u0645\u0627\u06cc\u0634 \u0622\u062f\u0631\u0633 \u0633\u0631\u0648\u0631 (\u0645\u06cc\u200c\u062a\u0648\u0627\u0646\u06cc\u062f \u062d\u0630\u0641 \u06a9\u0646\u06cc\u062f)
+  // ignore: avoid_print
+  print('API = ${AppConfig.apiBaseUrl}${AppConfig.apiPrefix}');
+
+  runApp(
+    MultiProvider(
+      providers: [
+        Provider<TokenStorage>.value(value: storage),
+        Provider<ApiClient>.value(value: api),
+        Provider<AuthRepository>.value(value: authRepo),
+        Provider<PatientRepository>.value(value: patientRepo),
+      ],
+      child: const App(),
+    ),
+  );
+}

--- a/gitdm_client/pubspec.yaml
+++ b/gitdm_client/pubspec.yaml
@@ -1,0 +1,21 @@
+name: gitdm_client
+description: Minimal Flutter client for GitDM backend.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  dio: ^5.7.0
+  shared_preferences: ^2.2.3
+  provider: ^6.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/gitdm_client/test/widget_test.dart
+++ b/gitdm_client/test/widget_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('dummy smoke', () {
+    // \u062a\u0633\u062a \u0633\u0627\u062f\u0647 \u0628\u0631\u0627\u06cc \u0627\u0637\u0645\u06cc\u0646\u0627\u0646 \u0627\u0632 \u0627\u062c\u0631\u0627\u06cc \u062a\u0633\u062a\u200c\u0647\u0627
+    expect(1 + 1, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- add minimal Flutter client with JWT auth, patient listing, and Persian comments
- support configurable API base URL via `--dart-define`
- include README and token refresh logic with Dio interceptor
- inject repositories via Provider for cleaner DI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc68eac2dc832081422e162925649d